### PR TITLE
docs: update supported k8s version

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -102,12 +102,9 @@ docker run quay.io/argoproj/kubectl-argo-rollouts:master version
 
 ## Supported versions
 
-At any point in time the officially supported version of Argo Rollouts is the latest released one, on Kubernetes versions N and N-1 (as supported by the Kubernetes project itself).
+Check [e2e testing file]( https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/e2e.yaml#L40-L44) to see what the Kubernetes version is being fully tested.
 
-For example if the latest minor version of Argo Rollouts is 1.2.1 and supported Kubernetes versions are 1.24, 1.23 and 1.22 then the following combinations are supported:
-
-* Argo Rollouts 1.2.1 on Kubernetes 1.24
-* Argo Rollouts 1.2.1 on Kubernetes 1.23
+You can switch to different tags to see what relevant Kubernetes versions were being tested for the respective version.
 
 ## Upgrading Argo Rollouts
 


### PR DESCRIPTION
We have many issues opened regarding the compatible issue of argo-rollouts and k8s. Based on @zachaller comment on this #2718 issue, I think we all agree:

1. the old docs is unclear and not true, argo-rollouts doesn't only support k8s N and N-1 version, sometime it support N-3 version 
2. the code is truth; as long as it's tested, we should be able to say argo-rollouts X version is compatible with k9s Y version

Resolves #2718

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [ ] I've signed my commits with [DCO](https://github.com/argoproj/argoproj)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).